### PR TITLE
Adding local storage capability (setting items in the storage)

### DIFF
--- a/sampleTODO_reactTs/src/store/todos.tsx
+++ b/sampleTODO_reactTs/src/store/todos.tsx
@@ -22,7 +22,16 @@ export const todosContext = createContext<TodosContext | null >(null)
 
 export const TodosProvider = ({children}:TodosProviderProps) => {
 
-    const[todos, setTodos] = useState<Todo[]> ([])
+    const[todos, setTodos] = useState<Todo[]> (() => {
+        try{
+            const newTodos = localStorage.getItem("todos") || "[]";
+            return JSON.parse(newTodos) as Todo[]
+
+        } catch (error) {
+            return []
+        }
+    })
+    // getting the localstorage data 
 
     const handleAddToDo = (task:string) => {
         setTodos((prev) => {
@@ -38,6 +47,7 @@ export const TodosProvider = ({children}:TodosProviderProps) => {
             // console.log("data from newtodos", {newTodos, prev})
 
             localStorage.setItem("todos", JSON.stringify(newTodos))
+            //setting the data
             return newTodos
         })
     }
@@ -53,6 +63,7 @@ export const TodosProvider = ({children}:TodosProviderProps) => {
                 return todo;
             })
             localStorage.setItem("todos", JSON.stringify(newTodos))
+            //setting the data
             return newTodos
         })
     }
@@ -62,6 +73,7 @@ export const TodosProvider = ({children}:TodosProviderProps) => {
         setTodos((prev) =>{
             let newTodos = prev.filter((filterTodo) => filterTodo.id !== id);
             localStorage.setItem("todos", JSON.stringify(newTodos))
+            //setting the data
             return newTodos;
         })
     }

--- a/sampleTODO_reactTs/src/store/todos.tsx
+++ b/sampleTODO_reactTs/src/store/todos.tsx
@@ -36,6 +36,8 @@ export const TodosProvider = ({children}:TodosProviderProps) => {
                 ...prev
             ]
             // console.log("data from newtodos", {newTodos, prev})
+
+            localStorage.setItem("todos", JSON.stringify(newTodos))
             return newTodos
         })
     }
@@ -50,6 +52,7 @@ export const TodosProvider = ({children}:TodosProviderProps) => {
                 }
                 return todo;
             })
+            localStorage.setItem("todos", JSON.stringify(newTodos))
             return newTodos
         })
     }
@@ -58,6 +61,7 @@ export const TodosProvider = ({children}:TodosProviderProps) => {
     const handleDeleteTodo = (id:String) => {
         setTodos((prev) =>{
             let newTodos = prev.filter((filterTodo) => filterTodo.id !== id);
+            localStorage.setItem("todos", JSON.stringify(newTodos))
             return newTodos;
         })
     }


### PR DESCRIPTION
In this PR, we will focus on adding local storage capability to add local storage.

In the 1st commit, setting data by stringifying the same,

![image](https://github.com/nayanbhargavapepcus/sampleProject/assets/116788157/484b930f-4099-4e16-bace-573e05186413)

in the 2nd commit, we are getting the set-data from our store

![image](https://github.com/nayanbhargavapepcus/sampleProject/assets/116788157/e4839df5-eb5e-4306-b4ea-352bfcbfeda3)

now even on refresh user would not loose there data
